### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -88,6 +88,13 @@ timestamp=$(date)
 AC_MSG_CHECKING([current timestamp])
 AC_MSG_RESULT([$timestamp])
 
+if test -n "$SOURCE_DATE_EPOCH"
+then
+  timestamp=$(date -u -d "@$SOURCE_DATE_EPOCH" 2>/dev/null || date -u -r "$SOURCE_DATE_EPOCH" 2>/dev/null || date -u)
+  username=reproducible
+  hostname=reproducible
+fi
+
 AC_DEFINE_UNQUOTED([STRESSAPPTEST_TIMESTAMP],
                    "$username @ $hostname on $timestamp",
                    [Timestamp when ./configure was executed])


### PR DESCRIPTION
Allow to override build date with SOURCE_DATE_EPOCH
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.
This date call works with all variants of date (GNU,BSD,Solaris).

Also do not capture build user+host in this case
to allow to get the same build results anywhere and anytime.

Without this patch, our openSUSE stressapptest package would vary for every build.

Also affects [Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=831587)