### PR TITLE
Add MIPS CPU support

### DIFF
--- a/configure
+++ b/configure
@@ -2499,6 +2499,12 @@ $as_echo "#define STRESSAPPTEST_CPU_X86_64 /**/" >>confdefs.h
 $as_echo "#define STRESSAPPTEST_CPU_I686 /**/" >>confdefs.h
 
      ;; #(
+  *mips*) :
+
+
+$as_echo "#define STRESSAPPTEST_CPU_MIPS /**/" >>confdefs.h
+
+     ;; #(
   *powerpc*) :
 
 
@@ -2518,8 +2524,8 @@ $as_echo "#define STRESSAPPTEST_CPU_AARCH64 /**/" >>confdefs.h
 
      ;; #(
   *) :
-    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unsupported CPU: $host_cpu! Try x86_64, i686, powerpc, armv7a, or aarch64" >&5
-$as_echo "$as_me: WARNING: Unsupported CPU: $host_cpu! Try x86_64, i686, powerpc, armv7a, or aarch64" >&2;}
+    { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Unsupported CPU: $host_cpu! Try x86_64, i686, mips, powerpc, armv7a, or aarch64" >&5
+$as_echo "$as_me: WARNING: Unsupported CPU: $host_cpu! Try x86_64, i686, mips, powerpc, armv7a, or aarch64" >&2;}
  ;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -23,6 +23,10 @@ AS_CASE(["$host_cpu"],
     AC_DEFINE([STRESSAPPTEST_CPU_I686],[],
               [Defined if the target CPU is i686])
     ], 
+  [*mips*], [
+    AC_DEFINE([STRESSAPPTEST_CPU_MIPS],[],
+              [Defined if the target CPU is MIPS])
+    ], 
   [*powerpc*], [
     AC_DEFINE([STRESSAPPTEST_CPU_PPC],[],
               [Defined if the target CPU is PowerPC])
@@ -35,7 +39,7 @@ AS_CASE(["$host_cpu"],
     AC_DEFINE([STRESSAPPTEST_CPU_AARCH64],[],
               [Defined if the target CPU is aarch64])
     ],
-[AC_MSG_WARN([Unsupported CPU: $host_cpu! Try x86_64, i686, powerpc, armv7a, or aarch64])]
+[AC_MSG_WARN([Unsupported CPU: $host_cpu! Try x86_64, i686, mips, powerpc, armv7a, or aarch64])]
 )
 
 ## The following allows like systems to share settings. This is not meant to

--- a/src/os.cc
+++ b/src/os.cc
@@ -206,6 +206,9 @@ void OsLayer::GetFeatures() {
 #elif defined(STRESSAPPTEST_CPU_PPC)
   // All PPC implementations have cache flush instructions.
   has_clflush_ = true;
+#elif defined(STRESSAPPTEST_CPU_MIPS)
+  // All MIPS implementations have cache flush instructions.
+  has_clflush_ = true;
 #elif defined(STRESSAPPTEST_CPU_ARMV7A)
   // TODO(nsanders): add detect from /proc/cpuinfo or /proc/self/auxv.
   // For now assume neon and don't run -W if you don't have it.

--- a/src/os.h
+++ b/src/os.h
@@ -153,6 +153,8 @@ class OsLayer {
     asm volatile("mfence");
     asm volatile("clflush (%0)" : : "r" (vaddr));
     asm volatile("mfence");
+#elif defined(STRESSAPPTEST_CPU_MIPS)
+    syscall(__NR_cacheflush, vaddr, 32, 0);
 #elif defined(STRESSAPPTEST_CPU_ARMV7A)
     // ARMv7a cachelines are 8 words (32 bytes).
     syscall(__ARM_NR_cacheflush, vaddr, reinterpret_cast<char*>(vaddr) + 32, 0);
@@ -192,7 +194,7 @@ class OsLayer {
       asm volatile("clflush (%0)" : : "r" (*vaddrs++));
     }
     asm volatile("mfence");
-#elif defined(STRESSAPPTEST_CPU_ARMV7A) || defined(STRESSAPPTEST_CPU_AARCH64)
+#elif defined(STRESSAPPTEST_CPU_MIPS) || defined(STRESSAPPTEST_CPU_ARMV7A) || defined(STRESSAPPTEST_CPU_AARCH64)
     while (*vaddrs) {
       FastFlush(*vaddrs++);
     }
@@ -217,7 +219,7 @@ class OsLayer {
     // instruction. For example, software can use an MFENCE instruction to
     // insure that previous stores are included in the write-back.
     asm volatile("clflush (%0)" : : "r" (vaddr));
-#elif defined(STRESSAPPTEST_CPU_ARMV7A) || defined(STRESSAPPTEST_CPU_AARCH64)
+#elif defined(STRESSAPPTEST_CPU_MIPS) || defined(STRESSAPPTEST_CPU_ARMV7A) || defined(STRESSAPPTEST_CPU_AARCH64)
     FastFlush(vaddr);
 #else
     #warning "Unsupported CPU type: Unable to force cache flushes."
@@ -242,7 +244,7 @@ class OsLayer {
     // instruction. For example, software can use an MFENCE instruction to
     // insure that previous stores are included in the write-back.
     asm volatile("mfence");
-#elif defined(STRESSAPPTEST_CPU_ARMV7A) || defined(STRESSAPPTEST_CPU_AARCH64)
+#elif defined(STRESSAPPTEST_CPU_MIPS) || defined(STRESSAPPTEST_CPU_ARMV7A) || defined(STRESSAPPTEST_CPU_AARCH64)
     // This is a NOP, FastFlushHint() always does a full flush, so there's
     // nothing to do for FastFlushSync().
 #else
@@ -272,6 +274,8 @@ class OsLayer {
     datacast_t data;
     __asm __volatile("rdtsc" : "=a" (data.l32.l), "=d"(data.l32.h));
     tsc = data.l64;
+#elif defined(STRESSAPPTEST_CPU_MIPS)
+    __asm __volatile("rdhwr  %0, $2\n" : "=r" (tsc));
 #elif defined(STRESSAPPTEST_CPU_ARMV7A)
     #warning "Unsupported CPU type ARMV7A: your timer may not function correctly"
     tsc = 0;

--- a/src/sattypes.h
+++ b/src/sattypes.h
@@ -223,6 +223,8 @@ inline void cpuid(
     : "a" (*eax)
   );  // Asm
 #endif  // defined(__PIC__) && defined(STRESSAPPTEST_CPU_I686)
+#elif defined(STRESSAPPTEST_CPU_MIPS)
+  return;
 #elif defined(STRESSAPPTEST_CPU_PPC)
   return;
 #elif defined(STRESSAPPTEST_CPU_ARMV7A)

--- a/src/stressapptest_config.h.in
+++ b/src/stressapptest_config.h.in
@@ -181,6 +181,9 @@
 /* Defined if the target CPU is i686 */
 #undef STRESSAPPTEST_CPU_I686
 
+/* Defined if the target CPU is MIPS */
+#undef STRESSAPPTEST_CPU_MIPS
+
 /* Defined if the target CPU is PowerPC */
 #undef STRESSAPPTEST_CPU_PPC
 

--- a/src/stressapptest_config_android.h
+++ b/src/stressapptest_config_android.h
@@ -176,6 +176,9 @@
 /* Defined if the target CPU is i686 */
 /* #undef STRESSAPPTEST_CPU_I686 */
 
+/* Defined if the target CPU is MIPS */
+/* #undef STRESSAPPTEST_CPU_MIPS */
+
 /* Defined if the target CPU is PowerPC */
 /* #undef STRESSAPPTEST_CPU_PPC */
 


### PR DESCRIPTION
* Add STRESSAPPTEST_CPU_MIPS definition.
* Implement cpuid(), GetFeatures(), FastFlush() and GetTimestamp()
  for MIPS.
* Eliminate "WARNING: Unsupported CPU ..." or similar warnings on MIPS.

Signed-off-by: Huacai Chen <chenhc@lemote.com>