### PR TITLE
Add stdint.h header in os.h to support static build

### DIFF
--- a/src/os.h
+++ b/src/os.h
@@ -19,6 +19,7 @@
 #include <dirent.h>
 #include <unistd.h>
 #include <sys/syscall.h>
+#include <stdint.h>
 
 #include <string>
 #include <list>


### PR DESCRIPTION
TEST=1. ./configure --host=aarch64-cros-linux-gnu --with-static
            2. `make -j` succeeds