### PR TITLE
add aarch64 vector copy

### DIFF
--- a/src/os.cc
+++ b/src/os.cc
@@ -208,7 +208,7 @@ void OsLayer::GetFeatures() {
 #elif defined(STRESSAPPTEST_CPU_MIPS)
   // All MIPS implementations have cache flush instructions.
   has_clflush_ = true;
-#elif defined(STRESSAPPTEST_CPU_ARMV7A)
+#elif defined(STRESSAPPTEST_CPU_ARMV7A) || defined(STRESSAPPTEST_CPU_AARCH64)
   // TODO(nsanders): add detect from /proc/cpuinfo or /proc/self/auxv.
   // For now assume neon and don't run -W if you don't have it.
   has_vector_ = true; // NEON.


### PR DESCRIPTION
Add vector acceleratin for aarch64
This improves memory copy speed by a
large factor on tested devices.

TEST=Run on device, see higher BW nmbers.
TEST=force errors still finds errors.
