### PR TITLE
Add --no_affinity flag

### DIFF
--- a/src/sat.cc
+++ b/src/sat.cc
@@ -722,6 +722,7 @@ Sat::Sat() {
   disk_threads_ = 0;
   total_threads_ = 0;
 
+  use_affinity_ = true;
   region_mask_ = 0;
   region_count_ = 0;
   for (int i = 0; i < 32; i++) {
@@ -867,6 +868,7 @@ bool Sat::ParseArgs(int argc, char **argv) {
     ARG_IVALUE("--filesize", filesize);
 
     // NUMA options.
+    ARG_KVALUE("--no_affinity", use_affinity_, false);
     ARG_KVALUE("--local_numa", region_mode_, kLocalNuma);
     ARG_KVALUE("--remote_numa", region_mode_, kRemoteNuma);
 
@@ -1155,6 +1157,7 @@ void Sat::PrintHelp() {
          " --paddr_base     allocate memory starting from this address\n"
          " --pause_delay    delay (in seconds) between power spikes\n"
          " --pause_duration duration (in seconds) of each pause\n"
+         " --no_affinity    do not set any cpu affinity\n"
          " --local_numa     choose memory regions associated with "
          "each CPU to be tested by that CPU\n"
          " --remote_numa    choose memory regions not associated with "
@@ -1388,7 +1391,6 @@ void Sat::InitializeThreads() {
       // Set thread affinity.
       thread->set_cpu_mask_to_cpu(nthbit);
     }
-
 
     cpu_vector->insert(cpu_vector->end(), thread);
   }

--- a/src/sat.h
+++ b/src/sat.h
@@ -91,6 +91,7 @@ class Sat {
   int errors() const { return errorcount_; }
   int warm() const { return warm_; }
   bool stop_on_error() const { return stop_on_error_; }
+  bool use_affinity() const { return use_affinity_; }
   int32 region_mask() const { return region_mask_; }
   // Semi-accessor to find the "nth" region to avoid replicated bit searching..
   int32 region_find(int32 num) const {
@@ -244,6 +245,7 @@ class Sat {
   // Block table for IO device.
   vector<DiskBlockTable*> blocktables_;
 
+  bool use_affinity_;                 // Should stressapptest set cpu affinity?
   int32 region_mask_;                 // Bitmask of available NUMA regions.
   int32 region_count_;                // Count of available NUMA regions.
   int32 region_[32];                  // Pagecount per region.

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -452,10 +452,13 @@ bool WorkerThread::BindToCpus(const cpu_set_t *thread_mask) {
     return false;
   }
 #ifdef HAVE_SCHED_GETAFFINITY
-  return (sched_setaffinity(gettid(), sizeof(*thread_mask), thread_mask) == 0);
-#else
-  return 0;
+  if (sat_->use_affinity()) {
+    return (sched_setaffinity(gettid(), sizeof(*thread_mask), thread_mask) == 0);
+  } else {
+    logprintf(11, "Log: Skipping CPU affinity set.\n");
+  }
 #endif
+  return true;
 }
 
 


### PR DESCRIPTION
For those who want to set custom affinity easily.

TEST=Doesn't call sched_setaffinity
