### PR TITLE
Fixes for musl/cross-compile/lfs64

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,6 +157,7 @@ AC_FUNC_STRERROR_R
 AC_FUNC_VPRINTF
 AC_CHECK_FUNCS([ftruncate gettimeofday memset munmap select socket strtol strtoull])
 AC_CHECK_FUNCS([mmap64 posix_memalign rand_r sched_getaffinity])
+AC_CHECK_FUNCS([pthread_rwlockattr_setkind_np])
 
 AC_CONFIG_FILES([Makefile src/Makefile])
 AC_OUTPUT

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,14 @@ else
   AC_MSG_NOTICE([Compiling with dynamically linked libraries.])
 fi
 
-AC_CANONICAL_HOST
+AC_ARG_WITH(cpu, [  --with-cpu            define host cpu])
+
+if test -z "$with_cpu"
+then
+  AC_CANONICAL_HOST
+else
+  host_cpu=$with_cpu
+fi
 # Checking for target cpu and setting custom configuration
 # for the different platforms
 AS_CASE(["$host_cpu"],

--- a/src/os.cc
+++ b/src/os.cc
@@ -142,7 +142,7 @@ int OsLayer::AddressMode() {
 uint64 OsLayer::VirtualToPhysical(void *vaddr) {
   uint64 frame, paddr, pfnmask, pagemask;
   int pagesize = sysconf(_SC_PAGESIZE);
-  off64_t off = ((uintptr_t)vaddr) / pagesize * 8;
+  off_t off = ((uintptr_t)vaddr) / pagesize * 8;
   int fd = open(kPagemapPath, O_RDONLY);
 
   /*
@@ -154,7 +154,7 @@ uint64 OsLayer::VirtualToPhysical(void *vaddr) {
   if (fd < 0)
     return 0;
 
-  if (lseek64(fd, off, SEEK_SET) != off || read(fd, &frame, 8) != 8) {
+  if (lseek(fd, off, SEEK_SET) != off || read(fd, &frame, 8) != 8) {
     int err = errno;
     string errtxt = ErrorString(err);
     logprintf(0, "Process Error: failed to access %s with errno %d (%s)\n",
@@ -607,9 +607,9 @@ bool OsLayer::AllocateTestMem(int64 length, uint64 paddr_base) {
         dynamic_mapped_shmem_ = true;
       } else {
         // Do a full mapping here otherwise.
-        shmaddr = mmap64(NULL, length, PROT_READ | PROT_WRITE,
-                         MAP_SHARED | MAP_NORESERVE | MAP_LOCKED | MAP_POPULATE,
-                         shm_object, 0);
+        shmaddr = mmap(NULL, length, PROT_READ | PROT_WRITE,
+                       MAP_SHARED | MAP_NORESERVE | MAP_LOCKED | MAP_POPULATE,
+                       shm_object, 0);
         if (shmaddr == reinterpret_cast<void*>(-1)) {
           int err = errno;
           string errtxt = ErrorString(err);
@@ -704,18 +704,12 @@ void *OsLayer::PrepareTestMem(uint64 offset, uint64 length) {
   if (dynamic_mapped_shmem_) {
     // TODO(nsanders): Check if we can support MAP_NONBLOCK,
     // and evaluate performance hit from not using it.
-#ifdef HAVE_MMAP64
-    void * mapping = mmap64(NULL, length, PROT_READ | PROT_WRITE,
-                     MAP_SHARED | MAP_NORESERVE | MAP_LOCKED | MAP_POPULATE,
-                     shmid_, offset);
-#else
     void * mapping = mmap(NULL, length, PROT_READ | PROT_WRITE,
                      MAP_SHARED | MAP_NORESERVE | MAP_LOCKED | MAP_POPULATE,
                      shmid_, offset);
-#endif
     if (mapping == MAP_FAILED) {
       string errtxt = ErrorString(errno);
-      logprintf(0, "Process Error: PrepareTestMem mmap64(%llx, %llx) failed. "
+      logprintf(0, "Process Error: PrepareTestMem mmap(%llx, %llx) failed. "
                    "error: %s.\n",
                 offset, length, errtxt.c_str());
       sat_assert(0);

--- a/src/sat.cc
+++ b/src/sat.cc
@@ -1484,15 +1484,47 @@ int Sat::CpuCount() {
   return sysconf(_SC_NPROCESSORS_CONF);
 }
 
+int Sat::ReadInt(const char *filename, int *value) {
+  char line[64];
+  int fd = open(filename, O_RDONLY), err = -1;
+
+  if (fd < 0)
+    return -1;
+  if (read(fd, line, sizeof(line)) > 0) {
+    *value = atoi(line);
+    err = 0;
+  }
+
+  close(fd);
+  return err;
+}
+
 // Return the worst case (largest) cache line size of the various levels of
 // cache actually prsent in the machine.
 int Sat::CacheLineSize() {
-  int max_linesize = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
-  int linesize = sysconf(_SC_LEVEL2_CACHE_LINESIZE);
+  int max_linesize, linesize;
+#ifdef _SC_LEVEL1_DCACHE_LINESIZE
+  max_linesize = sysconf(_SC_LEVEL1_DCACHE_LINESIZE);
+#else
+  ReadInt("/sys/devices/system/cpu/cpu0/cache/index0/coherency_line_size", &max_linesize);
+#endif
+#ifdef _SC_LEVEL2_DCACHE_LINESIZE
+  linesize = sysconf(_SC_LEVEL2_DCACHE_LINESIZE);
+#else
+  ReadInt("/sys/devices/system/cpu/cpu0/cache/index1/coherency_line_size", &linesize);
+#endif
   if (linesize > max_linesize) max_linesize = linesize;
-  linesize = sysconf(_SC_LEVEL3_CACHE_LINESIZE);
+#ifdef _SC_LEVEL3_DCACHE_LINESIZE
+  linesize = sysconf(_SC_LEVEL3_DCACHE_LINESIZE);
+#else
+  ReadInt("/sys/devices/system/cpu/cpu0/cache/index2/coherency_line_size", &linesize);
+#endif
   if (linesize > max_linesize) max_linesize = linesize;
-  linesize = sysconf(_SC_LEVEL4_CACHE_LINESIZE);
+#ifdef _SC_LEVEL4_DCACHE_LINESIZE
+  linesize = sysconf(_SC_LEVEL4_DCACHE_LINESIZE);
+#else
+  ReadInt("/sys/devices/system/cpu/cpu0/cache/index3/coherency_line_size", &linesize);
+#endif
   if (linesize > max_linesize) max_linesize = linesize;
   return max_linesize;
 }

--- a/src/sat.h
+++ b/src/sat.h
@@ -137,7 +137,8 @@ class Sat {
   int CpuCount();
   // Return the worst-case (largest) cache line size of the system.
   int CacheLineSize();
-
+  // Read int values from kernel file system e.g. sysfs
+  int ReadInt(const char *filename, int *value);
   // Collect error counts from threads.
   int64 GetTotalErrorCount();
 

--- a/src/sattypes.h
+++ b/src/sattypes.h
@@ -30,7 +30,9 @@
 #include "stressapptest_config_android.h"  // NOLINT
 #else
 #include "stressapptest_config.h"  // NOLINT
+#ifndef _LIBCPP_VERSION
 using namespace __gnu_cxx;  //NOLINT
+#endif  // _LIBCPP_VERSION
 #endif  // __ANDROID__
 using namespace std;
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -133,9 +133,11 @@ void WorkerStatus::Initialize() {
 
   pthread_rwlockattr_t attrs;
   sat_assert(0 == pthread_rwlockattr_init(&attrs));
+#ifdef HAVE_PTHREAD_RWLOCKATTR_SETKIND_NP
   // Avoid writer lock starvation.
   sat_assert(0 == pthread_rwlockattr_setkind_np(
                       &attrs, PTHREAD_RWLOCK_PREFER_WRITER_NONRECURSIVE_NP));
+#endif
   sat_assert(0 == pthread_rwlock_init(&status_rwlock_, &attrs));
 
 #ifdef HAVE_PTHREAD_BARRIERS

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -1705,7 +1705,7 @@ bool FileThread::WritePages(int fd) {
   int strict = sat_->strict();
 
   // Start fresh at beginning of file for each batch of pages.
-  lseek64(fd, 0, SEEK_SET);
+  lseek(fd, 0, SEEK_SET);
   for (int i = 0; i < sat_->disk_pages(); i++) {
     struct page_entry src;
     if (!GetValidPage(&src))
@@ -1943,7 +1943,7 @@ bool FileThread::ReadPages(int fd) {
   bool result = true;
 
   // Read our data back out of the file, into it's new location.
-  lseek64(fd, 0, SEEK_SET);
+  lseek(fd, 0, SEEK_SET);
   for (int i = 0; i < sat_->disk_pages(); i++) {
     struct page_entry dst;
     if (!GetEmptyPage(&dst))
@@ -3153,7 +3153,7 @@ bool DiskThread::ValidateBlockOnDisk(int fd, BlockData *block) {
 
   // Read block from disk and time the read.  If it takes longer than the
   // threshold, complain.
-  if (lseek64(fd, address * kSectorSize, SEEK_SET) == -1) {
+  if (lseek(fd, address * kSectorSize, SEEK_SET) == -1) {
     logprintf(0, "Process Error: Unable to seek to sector %lld in "
               "DiskThread::ValidateSectorsOnDisk on disk %s "
               "(thread %d).\n", address, device_name_.c_str(), thread_num_);


### PR DESCRIPTION
These fixes are fixing builds with clang/libc++ standard C++ library, musl and improves cross-compile support in general