### PR TITLE
Fix x86 compilation on some systems

### DIFF
--- a/src/os.h
+++ b/src/os.h
@@ -34,6 +34,7 @@
 
 #if defined(STRESSAPPTEST_CPU_X86_64) || defined(STRESSAPPTEST_CPU_I686)
 #include <immintrin.h>
+#include <x86intrin.h>
 #if defined(_MSC_VER)
 #include <intrin.h>
 #endif


### PR DESCRIPTION
Some systems (or system configurations) use a compiler version which does not have the x86 __rtdsc() intrinsic (and probably others) defined in immintrin.h.
On those systems, compilation for x86 arch will fail. This was reported on Debian 10, RHEL 8.x and Ubuntu 20.04.

It seems immintrin.h is mostly for x86 SIMD intrinsics, but some compilers also put __rtdsc() there.

x86intrin.h is supposed to include immintrin.h *and* define all the Intel processors intrinsics, so including it before immintrin.h.