### PR TITLE
configure.ac: Always call AC_CANONICAL_HOST

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,10 +13,10 @@ fi
 
 AC_ARG_WITH(cpu, [  --with-cpu            define host cpu])
 
-if test -z "$with_cpu"
+AC_CANONICAL_HOST
+
+if test -n "$with_cpu"
 then
-  AC_CANONICAL_HOST
-else
   host_cpu=$with_cpu
 fi
 # Checking for target cpu and setting custom configuration


### PR DESCRIPTION
This is required for host_os also with --with-cpu.

@kraj